### PR TITLE
Increased maxResponseBytes to avoid NIOTooManyBytesError

### DIFF
--- a/Sources/IppClient/HttpClient+Ipp.swift
+++ b/Sources/IppClient/HttpClient+Ipp.swift
@@ -13,7 +13,8 @@ public extension HTTPClient {
         _ request: IppRequest,
         authentication: IppAuthentication? = nil,
         data: consuming HTTPClientRequest.Body? = nil,
-        timeout: TimeAmount = .seconds(10)
+        timeout: TimeAmount = .seconds(10),
+        maxBytes: Int = 1024 * 1024
     ) async throws -> IppResponse {
         let httpRequest = try HTTPClientRequest(ippRequest: request, authentication: authentication, data: data)
         let httpResponse = try await execute(httpRequest, timeout: timeout)
@@ -22,7 +23,7 @@ public extension HTTPClient {
             throw IppHttpResponseError(response: httpResponse)
         }
 
-        var buffer = try await httpResponse.body.collect(upTo: 20 * 1024)
+        var buffer = try await httpResponse.body.collect(upTo: maxBytes)
         return try IppResponse(buffer: &buffer)
     }
 }

--- a/Sources/IppClient/HttpClient+Ipp.swift
+++ b/Sources/IppClient/HttpClient+Ipp.swift
@@ -14,7 +14,7 @@ public extension HTTPClient {
         authentication: IppAuthentication? = nil,
         data: consuming HTTPClientRequest.Body? = nil,
         timeout: TimeAmount = .seconds(10),
-        maxBytes: Int = 1024 * 1024
+        maxResponseBytes: Int = 1024 * 1024
     ) async throws -> IppResponse {
         let httpRequest = try HTTPClientRequest(ippRequest: request, authentication: authentication, data: data)
         let httpResponse = try await execute(httpRequest, timeout: timeout)
@@ -23,7 +23,7 @@ public extension HTTPClient {
             throw IppHttpResponseError(response: httpResponse)
         }
 
-        var buffer = try await httpResponse.body.collect(upTo: maxBytes)
+        var buffer = try await httpResponse.body.collect(upTo: maxResponseBytes)
         return try IppResponse(buffer: &buffer)
     }
 }


### PR DESCRIPTION
Calling getPrinterAttributes to request "printer-description", "job-template" and "media-col-database" (as per example at https://www.pwg.org/ipp/ippguide.html#querying-the-printer-attributes ) on Simulated InkJet results in an NIOTooManyBytesError. Raised the hardcoded max value to 1 MB instead of 20 KB and made it an optional param.